### PR TITLE
Linting for ninterpolate

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ gettext('foo' + variable)
 ngettext(varA, varB, 5)
 pgettext(varA, varB)
 npgettext(varA, varB, varC, 5)
+ninterpolate(varA, varB, 5)
+ninterpolate(varA, varB, 5, {})
 
 // Allows:
 gettext('hello')
@@ -52,6 +54,8 @@ pgettext('homepage', 'hello')
 npgettext('homepage', 'cat', '%d cats', 5)
 i18n.gettext('hello') // any object can expose the gettext API
 this.gettext('hello')
+ninterpolate('cat', '%d cats', 5)
+ninterpolate('cat', '%(count)s cats', 5, {count: 5})
 ```
 
 ### `gettext/required-positional-markers-for-multiple-variables`

--- a/__tests__/lib/rules/no-variable-string.js
+++ b/__tests__/lib/rules/no-variable-string.js
@@ -20,6 +20,8 @@ ruleTester.run('no-variable-string', ruleNoVariableString, {
         "i18n.pgettext('homePage', 'hello')",
         "npgettext('homepage', 'cat', '%d cats', 5)",
         "i18n.npgettext('homepage', 'cat', '%d cats', 5)",
+        "ninterpolate('cat', '%d cats', 5)",
+        "ninterpolate('cat', '%(count)s cats', 5, {count: 5})",
     ],
     invalid: [
         {
@@ -249,6 +251,24 @@ ruleTester.run('no-variable-string', ruleNoVariableString, {
         },
         {
             code: "npgettext('homepage', cat, '%d cats', 5)",
+            errors: [
+                {
+                    message: invalidMessage,
+                    type: 'Identifier',
+                },
+            ],
+        },
+        {
+            code: "ninterpolate(cat, 'cats', 5)",
+            errors: [
+                {
+                    message: invalidMessage,
+                    type: 'Identifier',
+                },
+            ],
+        },
+        {
+            code: "ninterpolate('cat', cats, 5)",
             errors: [
                 {
                     message: invalidMessage,

--- a/lib/rules/no-variable-string.js
+++ b/lib/rules/no-variable-string.js
@@ -81,6 +81,25 @@ const i18nMethodMap = {
 
         return catchError;
     },
+    ninterpolate(context, node) {
+        utils.checkRequiredArgument(context, node, 3);
+
+        let catchError = false;
+        const keyTxt = node.arguments[0];
+        const pluralTxt = node.arguments[1];
+
+        if (!utils.isStringLiteral(keyTxt)) {
+            context.report(utils.getReportNode(keyTxt, node), errorMsg);
+            catchError = true;
+        }
+
+        if (!utils.isStringLiteral(pluralTxt)) {
+            context.report(utils.getReportNode(pluralTxt, node), errorMsg);
+            catchError = true;
+        }
+
+        return catchError;
+    },
 };
 
 module.exports = {


### PR DESCRIPTION
@udemy/localization-infra adding linting for our special fancy nintepolate to make sure people pass strings to it, not variables, or gettext() wrapped strings. (pretty identical to the ngettext rule)