### PR TITLE
ESLint rule to forbid literal strings in interpolate calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ npm install eslint-plugin-gettext --save-dev
   "plugins": ["gettext"],
   "rules": {
     "gettext/no-variable-string": "error",
+    "gettext/no-interpolate-string": "error",
     "gettext/required-positional-markers-for-multiple-variables": "error"
   }
 }
@@ -56,6 +57,19 @@ i18n.gettext('hello') // any object can expose the gettext API
 this.gettext('hello')
 ninterpolate('cat', '%d cats', 5)
 ninterpolate('cat', '%(count)s cats', 5, {count: 5})
+```
+
+### `gettext/no-interpolate-string`
+
+Disallow literal strings inside `interpolate` functions. The interpolated string must be (a variable) wrapped with gettext.
+
+```js
+// Disallows:
+interpolate('bla')
+
+// Allows:
+interpolate(gettext('bla'))
+interpolate(hopefullyTranslatedVar)
 ```
 
 ### `gettext/required-positional-markers-for-multiple-variables`

--- a/__tests__/lib/rules/no-interpolate-string.js
+++ b/__tests__/lib/rules/no-interpolate-string.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const ruleNoInterpolateString = require('../../../lib/rules/no-interpolate-string');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester();
+const invalidMessage =
+    'Unexpected argument, interpolate function does not allow string literals as arguments.';
+
+ruleTester.run('no-interpolate-string', ruleNoInterpolateString, {
+    valid: ["interpolate(gettext('hello'))", 'interpolate(hopefullyTranslatedVar)'],
+    invalid: [
+        {
+            code: "interpolate('hello')",
+            errors: [
+                {
+                    message: invalidMessage,
+                    type: 'Literal',
+                },
+            ],
+        },
+    ],
+});

--- a/index.js
+++ b/index.js
@@ -3,9 +3,11 @@
 module.exports = {
     rules: {
         'no-variable-string': require('./lib/rules/no-variable-string'),
+        'no-interpolate-string': require('./lib/rules/no-interpolate-string'),
         'required-positional-markers-for-multiple-variables': require('./lib/rules/required-positional-markers-for-multiple-variables'),
     },
     rulesConfig: {
         'no-variable-string': 0,
+        'no-interpolate-string': 0,
     },
 };

--- a/lib/rules/no-interpolate-string.js
+++ b/lib/rules/no-interpolate-string.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const utils = require('../utils');
+
+const errorMsg =
+    'Unexpected argument, interpolate function does not allow string literals as arguments.';
+
+const i18nMethodMap = {
+    interpolate(context, node) {
+        const keyTxt = node.arguments[0];
+        if (utils.isStringLiteral(keyTxt)) {
+            const reportNode = utils.getReportNode(keyTxt, node);
+            context.report(reportNode, errorMsg);
+            return true;
+        }
+
+        return false;
+    },
+};
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                'Should interpolate translated string. Plain string is not allowed',
+            recommended: false,
+        },
+        fixable: null,
+        schema: [],
+    },
+
+    create: function(context) {
+        return {
+            CallExpression(node) {
+                Object.keys(i18nMethodMap).find(apiName => {
+                    if (utils.isI18nAPICall(node, apiName)) {
+                        return i18nMethodMap[apiName](context, node);
+                    }
+
+                    return false;
+                });
+            },
+        };
+    },
+};


### PR DESCRIPTION
@udemy/localization-infra @udemy/web-frontend another ESLint rule to complain about `interpolate('sometext'...)` which won't be translated. we have about ten in our codebase, so not that much, but still.